### PR TITLE
add drone pipeline `build flake update`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -30,3 +30,60 @@ trigger:
   event:
   - push
   - pull_request
+
+---
+kind: pipeline
+type: exec
+name: build flake update
+
+platform:
+  os: linux
+  arch: amd64
+
+clone:
+  depth: 1
+
+steps:
+
+- name: create result-old files
+  commands:
+  - nix build -v '.#nixosConfigurations.laptop.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
+  - mv result laptop-old
+  - nix build -v '.#nixosConfigurations.arm.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
+  - mv result arm-old
+
+- name: flake update
+  commands:
+  - nix --experimental-features "nix-command flakes" flake update
+  
+- name: Show git diff
+  commands:
+  - git diff
+
+- name: Show flake info
+  commands:
+  - nix --experimental-features "nix-command flakes" flake show
+  - nix --experimental-features "nix-command flakes" flake metadata
+  - nix --experimental-features "nix-command flakes" flake check
+
+- name: Build laptop
+  commands:
+  - nix build -v '.#nixosConfigurations.laptop.config.system.build.toplevel'
+  - mv result laptop-new
+
+- name: Build arm
+  commands:
+  - nix build -v '.#nixosConfigurations.arm.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
+  - mv result arm-new
+
+- name: Print report
+  commands:
+  - echo "laptop:" && nix store diff-closures $(readlink -f laptop-old) $(readlink -f laptop-new)
+  - echo "arm:" && nix store diff-closures $(readlink -f arm-old) $(readlink -f arm-new)
+
+trigger:
+  branch:
+  - main
+  event:
+  - pull_request
+  - cron


### PR DESCRIPTION
This pipeline make sure, the binary cache contains binaries for a possible update.

Explanation:
```trigger: cron```
1. builds hosts in current state, saves the result file under new name
2. updates flake.lock
3. builds hosts again
4. compares result files

This PR has no impact on the systems themselves.