### PR TITLE
split .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -38,7 +38,7 @@ steps:
 
   - name: Build laptop
     commands:
-      - nix build -v '.#nixosConfigurations.laptop.config.system.build.toplevel' --show-trace --option binary-caches "https://cache.nixos.org"
+      - nix build -v -L '.#nixosConfigurations.laptop.config.system.build.toplevel' --show-trace --option binary-caches "https://cache.nixos.org"
 
 trigger:
   event:
@@ -61,7 +61,7 @@ steps:
 
   - name: Build desktop
     commands:
-      - nix build -v '.#nixosConfigurations.desktop.config.system.build.toplevel' --show-trace --option binary-caches "https://cache.nixos.org"
+      - nix build -v -L '.#nixosConfigurations.desktop.config.system.build.toplevel' --show-trace --option binary-caches "https://cache.nixos.org"
 
 trigger:
   event:
@@ -84,7 +84,7 @@ steps:
 
   - name: Build arm
     commands:
-      - nix build -v '.#nixosConfigurations.arm.config.system.build.toplevel' --show-trace --option binary-caches "https://cache.nixos.org"
+      - nix build -v -L '.#nixosConfigurations.arm.config.system.build.toplevel' --show-trace --option binary-caches "https://cache.nixos.org"
 
 trigger:
   event:
@@ -121,15 +121,15 @@ steps:
 
   - name: Build laptop
     commands:
-      - nix build -v '.#nixosConfigurations.laptop.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
+      - nix build -v -L '.#nixosConfigurations.laptop.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
 
   - name: Build desktop
     commands:
-      - nix build -v '.#nixosConfigurations.desktop.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
+      - nix build -v -L '.#nixosConfigurations.desktop.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
 
   - name: Build arm
     commands:
-      - nix build -v '.#nixosConfigurations.arm.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
+      - nix build -v -L '.#nixosConfigurations.arm.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
 
 trigger:
   branch:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 kind: pipeline
 type: exec
-name: Build all hosts
+name: Show flake info
 
 platform:
   os: linux
@@ -17,21 +17,74 @@ steps:
       - nix flake metadata
       - nix flake check
 
+trigger:
+  event:
+    - push
+    - pull_request
+
+---
+kind: pipeline
+type: exec
+name: build laptop
+
+platform:
+  os: linux
+  arch: amd64
+
+clone:
+  depth: 1
+
+steps:
+
   - name: Build laptop
     commands:
-      - nix build -v '.#nixosConfigurations.laptop.config.system.build.toplevel' --show-trace --cores 6
+      - nix build -v '.#nixosConfigurations.laptop.config.system.build.toplevel' --show-trace --option binary-caches "https://cache.nixos.org"
+
+trigger:
+  event:
+    - push
+    - pull_request
+
+---
+kind: pipeline
+type: exec
+name: build desktop
+
+platform:
+  os: linux
+  arch: amd64
+
+clone:
+  depth: 1
+
+steps:
 
   - name: Build desktop
     commands:
-      - nix build -v '.#nixosConfigurations.desktop.config.system.build.toplevel' --show-trace --cores 6
+      - nix build -v '.#nixosConfigurations.desktop.config.system.build.toplevel' --show-trace --option binary-caches "https://cache.nixos.org"
+
+trigger:
+  event:
+    - push
+    - pull_request
+
+---
+kind: pipeline
+type: exec
+name: build arm
+
+platform:
+  os: linux
+  arch: amd64
+
+clone:
+  depth: 1
+
+steps:
 
   - name: Build arm
     commands:
-      - nix build -v '.#nixosConfigurations.arm.config.system.build.toplevel' --show-trace --cores 6
-
-  # - name: Build pi4b
-  #   commands:
-  #     - nix build -v '.#nixosConfigurations.pi4b.config.system.build.toplevel' --show-trace
+      - nix build -v '.#nixosConfigurations.arm.config.system.build.toplevel' --show-trace --option binary-caches "https://cache.nixos.org"
 
 trigger:
   event:
@@ -51,16 +104,6 @@ clone:
   depth: 1
 
 steps:
-  - name: create result-old files
-    commands:
-      - nix build -v '.#nixosConfigurations.laptop.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
-      - mv result laptop-old
-      - nix build -v '.#nixosConfigurations.desktop.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
-      - mv result desktop-old
-      - nix build -v '.#nixosConfigurations.arm.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
-      - mv result arm-old
-      # - nix build -v '.#nixosConfigurations.pi4b.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
-      # - mv result pi4b-old
 
   - name: flake update
     commands:
@@ -78,12 +121,69 @@ steps:
 
   - name: Build laptop
     commands:
-      - nix build -v '.#nixosConfigurations.laptop.config.system.build.toplevel'
+      - nix build -v '.#nixosConfigurations.laptop.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
+
+  - name: Build desktop
+    commands:
+      - nix build -v '.#nixosConfigurations.desktop.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
+
+  - name: Build arm
+    commands:
+      - nix build -v '.#nixosConfigurations.arm.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
+
+trigger:
+  branch:
+    - main
+  event:
+    - push
+    - pull_request
+    - cron
+
+---
+kind: pipeline
+type: exec
+name: show flake diff
+
+platform:
+  os: linux
+  arch: amd64
+
+clone:
+  depth: 1
+
+steps:
+
+  - name: create result-old files
+    commands:
+      - nix build -v '.#nixosConfigurations.laptop.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
+      - mv result laptop-old
+      - nix build -v '.#nixosConfigurations.desktop.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
+      - mv result desktop-old
+      - nix build -v '.#nixosConfigurations.arm.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
+      - mv result arm-old
+
+  - name: flake update
+    commands:
+      - nix --experimental-features "nix-command flakes" flake update
+
+  - name: Show git diff
+    commands:
+      - git diff
+
+  - name: Show flake info
+    commands:
+      - nix --experimental-features "nix-command flakes" flake show
+      - nix --experimental-features "nix-command flakes" flake metadata
+      - nix --experimental-features "nix-command flakes" flake check
+
+  - name: Build laptop
+    commands:
+      - nix build -v '.#nixosConfigurations.laptop.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
       - mv result laptop-new
 
   - name: Build desktop
     commands:
-      - nix build -v '.#nixosConfigurations.desktop.config.system.build.toplevel'
+      - nix build -v '.#nixosConfigurations.desktop.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
       - mv result desktop-new
 
   - name: Build arm
@@ -91,23 +191,16 @@ steps:
       - nix build -v '.#nixosConfigurations.arm.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
       - mv result arm-new
 
-  # - name: Build pi4b
-  #   commands:
-  #     - nix build -v '.#nixosConfigurations.pi4b.config.system.build.toplevel' --option binary-caches "https://cache.nixos.org"
-  #     - mv result pi4b-new
-
   - name: Print report
     commands:
       - echo "laptop:" && nix store diff-closures $(readlink -f laptop-old) $(readlink -f laptop-new)
       - echo "desktop:" && nix store diff-closures $(readlink -f desktop-old) $(readlink -f desktop-new)
       - echo "arm:" && nix store diff-closures $(readlink -f arm-old) $(readlink -f arm-new)
-      # - echo "pi4b:" && nix store diff-closures $(readlink -f pi4b-old) $(readlink -f pi4b-new)
 
 trigger:
   branch:
     - main
   event:
-    - pull_request
     - cron
 
 ---

--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1638553958,
-        "narHash": "sha256-leETjYMtD9y37CvfRSQhIGibcIl4dNVlFkY/8QgqmAM=",
+        "lastModified": 1639871969,
+        "narHash": "sha256-6feWUnMygRzA9tzkrfAzpA5/NBYg75bkFxnqb1DtD7E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6ce1d64073f48b9bc9425218803b1b607454c1e7",
+        "rev": "697cc8c68ed6a606296efbbe9614c32537078756",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1639345229,
-        "narHash": "sha256-8a1eyHvg8Ck89b1ob39BtDHMpwbMYbQ2eGPF3hAD4MQ=",
+        "lastModified": 1639952154,
+        "narHash": "sha256-Y1504y/wfHSisTGjYeeqj/0ErSfxGuBHZXE4BA0ajWc=",
         "owner": "mayniklas",
         "repo": "nixos",
-        "rev": "4f171ccd60cc73d95cf2cb676fb7d12015d587b4",
+        "rev": "92c0b5cecc48e26c8e799dc14f8915a2295da800",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1639161226,
-        "narHash": "sha256-75Y08ynJDTq6HHGIF+8IADBJSVip0UyWQH7jqSFnRR8=",
+        "lastModified": 1639891440,
+        "narHash": "sha256-FJxa6ObwOQKZy3VhwN5bJRzX+MV/Yq9WLHK/4jlPKrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "573095944e7c1d58d30fc679c81af63668b54056",
+        "rev": "e6377ff35544226392b49fa2cf05590f9f0c4b43",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1639479055,
-        "narHash": "sha256-1TsBjCvZsfC3me2xP7zk3R8j/U4Hju3mXkyt0zWoKqU=",
+        "lastModified": 1639997288,
+        "narHash": "sha256-RDsZuvh3qzjR/YCWlxnqcSRGxcfxoKvj5D8mCvuTQKk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d71be4f43c662d1c646f6af527e631383286f7e9",
+        "rev": "e0e8ca98c71b464f94c1566dedcf076c11ee9b6b",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1639347265,
-        "narHash": "sha256-q5feWoC64+h6T6J89o2HJJ8DOnB/4vwMODBlZIgeIlA=",
+        "lastModified": 1639876010,
+        "narHash": "sha256-naGsoUfsY92NaIGiFI8XFXBnesw8BQGe694xcfaLMDI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b0bf5f888d377dd2f36d90340df6dc9f035aaada",
+        "rev": "395879c28386e1abf20c7ecacd45880759548391",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
By splitting the different build processes into different workflows, we have less dependencies:
Host 2 can still build in case Host 1 fails.
Also: nix flake update gets build when nix build fails.